### PR TITLE
Add `proto='tcp'` kwarg to `port_for`

### DIFF
--- a/src/pytest_docker/__init__.py
+++ b/src/pytest_docker/__init__.py
@@ -54,7 +54,7 @@ class Services(object):
     _docker_compose = attr.ib()
     _services = attr.ib(init=False, default=attr.Factory(dict))
 
-    def port_for(self, service, port):
+    def port_for(self, service, port, proto='tcp'):
         """Get the effective bind port for a service."""
 
         # Lookup in the cache.
@@ -63,12 +63,13 @@ class Services(object):
             return cache
 
         output = self._docker_compose.execute(
-            'port %s %d' % (service, port,)
+            'port --protocol=%s %s %d' % (proto, service, port)
         )
         endpoint = output.strip()
         if not endpoint:
             raise ValueError(
-                'Could not detect port for "%s:%d".' % (service, port)
+                'Could not detect port for "%s:%d/%s".' %
+                (service, port, proto)
             )
 
         # Usually, the IP address here is 0.0.0.0, so we don't use it.

--- a/tests/test_docker_services.py
+++ b/tests/test_docker_services.py
@@ -58,11 +58,50 @@ def test_docker_services():
         ),
         mock.call(
             'docker-compose -f "docker-compose.yml" -p "pytest123" '
-            'port abc 123',
+            'port --protocol=tcp abc 123',
             shell=True, stderr=subprocess.STDOUT,
         ),
         mock.call(
             'docker-compose -f "docker-compose.yml" -p "pytest123" down -v',
+            shell=True, stderr=subprocess.STDOUT,
+        ),
+    ]
+
+
+def test_docker_services_port_for_proto():
+    """Test port_for with proto=udp"""
+    with mock.patch('subprocess.check_output') as check_output:
+        check_output.side_effect = [b'', b'0.0.0.0:32770', b'']
+        check_output.returncode = 0
+
+        assert check_output.call_count == 0
+
+        # The fixture is a context-manager.
+        gen = docker_services(
+            'docker-compose.yml',
+            docker_compose_project_name='pytest123',
+        )
+        services = next(gen)
+        assert isinstance(services, Services)
+
+        assert check_output.call_count == 1
+
+        # Can request port for services.
+        port = services.port_for('abc', 123, 'udp')
+        assert port == 32770
+
+        assert check_output.call_count == 2
+
+    # Both should have been called.
+    assert check_output.call_args_list == [
+        mock.call(
+            'docker-compose -f "docker-compose.yml" -p "pytest123" '
+            'up --build -d',
+            shell=True, stderr=subprocess.STDOUT,
+        ),
+        mock.call(
+            'docker-compose -f "docker-compose.yml" -p "pytest123" '
+            'port --protocol=udp abc 123',
             shell=True, stderr=subprocess.STDOUT,
         ),
     ]
@@ -91,7 +130,7 @@ def test_docker_services_unused_port():
         with pytest.raises(ValueError) as exc:
             print(services.port_for('abc', 123))
         assert str(exc.value) == (
-            'Could not detect port for "%s:%d".' % ('abc', 123)
+            'Could not detect port for "%s:%d/tcp".' % ('abc', 123)
         )
 
         assert check_output.call_count == 2
@@ -111,7 +150,7 @@ def test_docker_services_unused_port():
         ),
         mock.call(
             'docker-compose -f "docker-compose.yml" -p "pytest123" '
-            'port abc 123',
+            'port --protocol=tcp abc 123',
             shell=True, stderr=subprocess.STDOUT,
         ),
         mock.call(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -39,7 +39,8 @@ def test_main_fixtures_work(docker_ip, docker_services):
     assert response.status_code == 204
 
 
-def test_containers_and_volumes_get_cleaned_up(testdir, tmpdir, docker_compose_file):
+def test_containers_and_volumes_get_cleaned_up(
+        testdir, tmpdir, docker_compose_file):
     _copy_compose_files_to_testdir(testdir, docker_compose_file)
 
     project_name_file_path = path.join(str(tmpdir), 'project_name.txt')
@@ -80,7 +81,8 @@ def _copy_compose_files_to_testdir(testdir, compose_file_path):
     directory_for_compose_files = testdir.mkdir('tests')
     shutil.copy(compose_file_path, str(directory_for_compose_files))
 
-    container_build_files_dir = path.realpath(path.join(compose_file_path, '../containers'))
+    container_build_files_dir = path.realpath(
+        path.join(compose_file_path, '../containers'))
     shutil.copytree(
         container_build_files_dir,
         str(directory_for_compose_files) + '/containers',


### PR DESCRIPTION
I have a use case where I need to get the udp port for a service.