### PR TITLE
WIP: Fix tests after calling fixture functions directly became an error\

### DIFF
--- a/tests/test_docker_ip.py
+++ b/tests/test_docker_ip.py
@@ -4,33 +4,44 @@
 import mock
 import pytest
 
+import pytest_docker
 from pytest_docker import docker_ip
 
-
-def test_docker_ip_native():
-    environ = {}
-    with mock.patch('os.environ', environ):
-        assert docker_ip() == '127.0.0.1'
+IP_FIXTURE_NAME = docker_ip.__name__
 
 
-def test_docker_ip_remote():
-    environ = {
-        'DOCKER_HOST': 'tcp://1.2.3.4:2376',
-    }
-    with mock.patch('os.environ', environ):
-        assert docker_ip() == '1.2.3.4'
+def test_docker_ip_native(monkeypatch, testdir):
+    monkeypatch.setenv('DOCKER_HOST', '')
+
+    testdir.makepyfile("""
+    def test_docker_ip(docker_ip):
+        assert docker_ip == '127.0.0.1'
+    """)
+
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1)
 
 
-@pytest.mark.parametrize('docker_host', [
-    'http://1.2.3.4:2376',
-])
-def test_docker_ip_remote_invalid(docker_host):
-    environ = {
-        'DOCKER_HOST': docker_host,
-    }
-    with mock.patch('os.environ', environ):
+def test_docker_ip_remote(testdir, monkeypatch):
+    monkeypatch.setenv('DOCKER_HOST', 'tcp://1.2.3.4:2376')
+
+    testdir.makepyfile("""
+    def test_docker_ip(docker_ip):
+        assert docker_ip == '1.2.3.4'
+    """)
+
+    result = testdir.runpytest()
+    result.assert_outcomes(passed=1)
+
+
+def test_docker_ip_remote_invalid(monkeypatch, testdir):
+    monkeypatch.setenv('DOCKER_HOST', 'http://1.2.3.4:2376')
+
+    testdir.makepyfile("""
+    def test_docker_ip_invalid(request):
         with pytest.raises(ValueError) as exc:
-            print(docker_ip())
+            request.getfixturevalue(IP_FIXTURE_NAME)
         assert str(exc.value) == (
             'Invalid value for DOCKER_HOST: "%s".' % (docker_host,)
         )
+    """)


### PR DESCRIPTION
This is still work in progress, cause I only fixed one file.
I'm not sure if I should carry on with this fix, though, cause the other broken file - `test_docker_services.py` has brittle, mock-ridden tests, which I would gladly replace with some functional tests that don't rely on mocking.