### PR TITLE
Fix attrs "convert" argument deprecation (19.2.0)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(
         ],
     },
     install_requires=[
-        'attrs>=16',
+        'attrs>=17.4',
     ],
 )

--- a/src/pytest_docker/__init__.py
+++ b/src/pytest_docker/__init__.py
@@ -104,7 +104,7 @@ def str_to_list(arg):
 
 @attr.s(frozen=True)
 class DockerComposeExecutor(object):
-    _compose_files = attr.ib(convert=str_to_list)
+    _compose_files = attr.ib(converter=str_to_list)
     _compose_project_name = attr.ib()
 
     def execute(self, subcommand):


### PR DESCRIPTION
Hi,

attrs 17.4 started deprecating the 'convert' argument in favor of 'converter'. Now version 19.2.0 was released with the old 'convert' argument removed.
This patch fixes that.

tox is not running through because of other issues I don't have time for right now, unfortunately.