### PR TITLE
Align with new version of attrs lib and fix tests

### DIFF
--- a/src/pytest_docker/__init__.py
+++ b/src/pytest_docker/__init__.py
@@ -2,6 +2,7 @@
 
 
 import attr
+import contextlib
 import os
 import pytest
 import re
@@ -29,10 +30,7 @@ def execute(command, success_codes=(0,)):
     return output
 
 
-@pytest.fixture(scope='session')
-def docker_ip():
-    """Determine IP address for TCP connections to Docker containers."""
-
+def get_docker_ip():
     # When talking to the Docker daemon via a UNIX socket, route all TCP
     # traffic to docker containers via the TCP loopback interface.
     docker_host = os.environ.get('DOCKER_HOST', '').strip()
@@ -45,6 +43,12 @@ def docker_ip():
             'Invalid value for DOCKER_HOST: "%s".' % (docker_host,)
         )
     return match.group(1)
+
+
+@pytest.fixture(scope='session')
+def docker_ip():
+    """Determine IP address for TCP connections to Docker containers."""
+    return get_docker_ip()
 
 
 @attr.s(frozen=True)
@@ -138,12 +142,10 @@ def docker_compose_project_name():
     return "pytest{}".format(os.getpid())
 
 
-@pytest.fixture(scope='session')
-def docker_services(
+@contextlib.contextmanager
+def get_docker_services(
     docker_compose_file, docker_compose_project_name
 ):
-    """Ensure all Docker-based services are up and running."""
-
     docker_compose = DockerComposeExecutor(
         docker_compose_file, docker_compose_project_name
     )
@@ -156,6 +158,17 @@ def docker_services(
 
     # Clean up.
     docker_compose.execute('down -v')
+
+
+@pytest.fixture(scope='session')
+def docker_services(
+    docker_compose_file, docker_compose_project_name
+):
+    """Ensure all Docker-based services are up and running."""
+    with get_docker_services(
+        docker_compose_file, docker_compose_project_name
+    ) as ds:
+        yield ds
 
 
 __all__ = (

--- a/src/pytest_docker/__init__.py
+++ b/src/pytest_docker/__init__.py
@@ -104,7 +104,7 @@ def str_to_list(arg):
 
 @attr.s(frozen=True)
 class DockerComposeExecutor(object):
-    _compose_files = attr.ib(convert=str_to_list)
+    _compose_files = attr.ib(converter=str_to_list)
     _compose_project_name = attr.ib()
 
     def execute(self, subcommand):

--- a/tests/test_docker_ip.py
+++ b/tests/test_docker_ip.py
@@ -4,13 +4,13 @@
 import mock
 import pytest
 
-from pytest_docker import docker_ip
+from pytest_docker import get_docker_ip
 
 
 def test_docker_ip_native():
     environ = {}
     with mock.patch('os.environ', environ):
-        assert docker_ip() == '127.0.0.1'
+        assert get_docker_ip() == '127.0.0.1'
 
 
 def test_docker_ip_remote():
@@ -18,7 +18,7 @@ def test_docker_ip_remote():
         'DOCKER_HOST': 'tcp://1.2.3.4:2376',
     }
     with mock.patch('os.environ', environ):
-        assert docker_ip() == '1.2.3.4'
+        assert get_docker_ip() == '1.2.3.4'
 
 
 @pytest.mark.parametrize('docker_host', [
@@ -30,7 +30,7 @@ def test_docker_ip_remote_invalid(docker_host):
     }
     with mock.patch('os.environ', environ):
         with pytest.raises(ValueError) as exc:
-            print(docker_ip())
+            print(get_docker_ip())
         assert str(exc.value) == (
             'Invalid value for DOCKER_HOST: "%s".' % (docker_host,)
         )

--- a/tests/test_docker_services.py
+++ b/tests/test_docker_services.py
@@ -7,7 +7,7 @@ import subprocess
 
 from pytest_docker import (
     DockerComposeExecutor,
-    docker_services,
+    get_docker_services,
     Services,
 )
 
@@ -22,30 +22,25 @@ def test_docker_services():
         assert check_output.call_count == 0
 
         # The fixture is a context-manager.
-        gen = docker_services(
+        with get_docker_services(
             'docker-compose.yml',
             docker_compose_project_name='pytest123',
-        )
-        services = next(gen)
-        assert isinstance(services, Services)
+        ) as services:
+            assert isinstance(services, Services)
 
-        assert check_output.call_count == 1
+            assert check_output.call_count == 1
 
-        # Can request port for services.
-        port = services.port_for('abc', 123)
-        assert port == 32770
+            # Can request port for services.
+            port = services.port_for('abc', 123)
+            assert port == 32770
 
-        assert check_output.call_count == 2
+            assert check_output.call_count == 2
 
-        # 2nd request for same service should hit the cache.
-        port = services.port_for('abc', 123)
-        assert port == 32770
+            # 2nd request for same service should hit the cache.
+            port = services.port_for('abc', 123)
+            assert port == 32770
 
-        assert check_output.call_count == 2
-
-        # Next yield is last.
-        with pytest.raises(StopIteration):
-            print(next(gen))
+            assert check_output.call_count == 2
 
         assert check_output.call_count == 3
 
@@ -78,27 +73,22 @@ def test_docker_services_unused_port():
         assert check_output.call_count == 0
 
         # The fixture is a context-manager.
-        gen = docker_services(
+        with get_docker_services(
             'docker-compose.yml',
             docker_compose_project_name='pytest123',
-        )
-        services = next(gen)
-        assert isinstance(services, Services)
+        ) as services:
+            assert isinstance(services, Services)
 
-        assert check_output.call_count == 1
+            assert check_output.call_count == 1
 
-        # Can request port for services.
-        with pytest.raises(ValueError) as exc:
-            print(services.port_for('abc', 123))
-        assert str(exc.value) == (
-            'Could not detect port for "%s:%d".' % ('abc', 123)
-        )
+            # Can request port for services.
+            with pytest.raises(ValueError) as exc:
+                print(services.port_for('abc', 123))
+            assert str(exc.value) == (
+                'Could not detect port for "%s:%d".' % ('abc', 123)
+            )
 
-        assert check_output.call_count == 2
-
-        # Next yield is last.
-        with pytest.raises(StopIteration):
-            print(next(gen))
+            assert check_output.call_count == 2
 
         assert check_output.call_count == 3
 
@@ -133,16 +123,14 @@ def test_docker_services_failure():
         check_output.returncode = 1
 
         # The fixture is a context-manager.
-        gen = docker_services(
-            'docker-compose.yml',
-            docker_compose_project_name='pytest123',
-        )
-
-        assert check_output.call_count == 0
+        with pytest.raises(Exception) as exc:
+            with get_docker_services(
+                'docker-compose.yml',
+                docker_compose_project_name='pytest123',
+            ):
+                pass
 
         # Failure propagates with improved diagnoatics.
-        with pytest.raises(Exception) as exc:
-            print(next(gen))
         assert str(exc.value) == (
             'Command %r returned %d: """%s""".' % (
                 "the command", 1, 'the output',

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -39,7 +39,9 @@ def test_main_fixtures_work(docker_ip, docker_services):
     assert response.status_code == 204
 
 
-def test_containers_and_volumes_get_cleaned_up(testdir, tmpdir, docker_compose_file):
+def test_containers_and_volumes_get_cleaned_up(
+    testdir, tmpdir, docker_compose_file
+):
     _copy_compose_files_to_testdir(testdir, docker_compose_file)
 
     project_name_file_path = path.join(str(tmpdir), 'project_name.txt')
@@ -80,7 +82,9 @@ def _copy_compose_files_to_testdir(testdir, compose_file_path):
     directory_for_compose_files = testdir.mkdir('tests')
     shutil.copy(compose_file_path, str(directory_for_compose_files))
 
-    container_build_files_dir = path.realpath(path.join(compose_file_path, '../containers'))
+    container_build_files_dir = path.realpath(
+        path.join(compose_file_path, '../containers')
+    )
     shutil.copytree(
         container_build_files_dir,
         str(directory_for_compose_files) + '/containers',


### PR DESCRIPTION
A keyword convert was deprecated and converter should be used instead.
https://github.com/python-attrs/attrs/issues/307

Fixes: https://github.com/AndreLouisCaron/pytest-docker/issues/39 
Fixes: https://github.com/AndreLouisCaron/pytest-docker/issues/35

Signed-off-by: Lukas Bednar <lbednar@redhat.com>