### PR TITLE
Version 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 0.8.0
+- Changes:
+	- Add explicit dependencies on `docker-compose` and `pytest`
+	- Stop using deprecated `pytest-runner` to run package tests
+
 ## Version 0.7.2
 - Changes:
 	- Update package README

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytest-docker
-version =  0.7.2
+version =  0.8.0
 description = Simple pytest fixtures for Docker and docker-compose based tests
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -33,19 +33,15 @@ package_dir=
 packages=pytest_docker
 
 install_requires =
-    attrs >=19, <20
-
-tests_require =
-    requests >=2.22.0, <3.0
     pytest >=5.0, <6.0
+    attrs >=19, <20
+    docker-compose >=1.26.0, <2.0  # TODO: Require 1.26.1 once it is out
+
+[options.extras_require]
+tests =
+    requests >=2.22.0, <3.0
     pytest-pylint >=0.14.1, <1.0
     pytest-pycodestyle >=2.0.0, <3.0
-
-[options.packages.find]
-where=src
-
-[aliases]
-test=pytest
 
 [tool:pytest]
 addopts = --verbose --pylint-rcfile=setup.cfg --pylint --pycodestyle

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
 setup(
-    setup_requires=["wheel >= 0.32", "pytest-runner >= 5.0, <6.0"],
+    setup_requires=["wheel >= 0.32"],
     entry_points={"pytest11": ["docker = pytest_docker"]},
 )

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,4 @@ passenv =
   DOCKER_TLS_VERIFY
 
 commands =
-    python setup.py test
+    pytest


### PR DESCRIPTION
- Changes:
	- Add explicit dependencies on `docker-compose` and `pytest`
	- Stop using deprecated `pytest-runner` to run package tests