### PR TITLE
Provide fixture for docker cleanup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ your tests if you need a particular project name.
 Start all services from the docker compose file (`docker-compose up`).
 After test are finished, shutdown all services (`docker-compose down`).
 
+### `docker_cleanup`
+
+Get the docker compose command to execute for test clean-up actions. Override
+this fixture in your tests if you need custom clean-up actions.
 
 # Contributing
 This pytest plug-in and its source code are made available to you under a MIT

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytest-docker
-version =  0.8.0
+version =  0.9.0
 description = Simple pytest fixtures for Docker and docker-compose based tests
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/pytest_docker/plugin.py
+++ b/src/pytest_docker/plugin.py
@@ -140,8 +140,18 @@ def docker_compose_project_name():
     return "pytest{}".format(os.getpid())
 
 
+@pytest.fixture(scope="session")
+def docker_cleanup():
+    """Get the docker_compose command to be executed for test clean-up actions.
+     Override this fixture in your tests if you need to change clean-up actions."""
+
+    return "down -v"
+
+
 @contextlib.contextmanager
-def get_docker_services(docker_compose_file, docker_compose_project_name):
+def get_docker_services(
+    docker_compose_file, docker_compose_project_name, docker_cleanup
+):
     docker_compose = DockerComposeExecutor(
         docker_compose_file, docker_compose_project_name
     )
@@ -153,7 +163,7 @@ def get_docker_services(docker_compose_file, docker_compose_project_name):
     yield Services(docker_compose)
 
     # Clean up.
-    docker_compose.execute("down -v")
+    docker_compose.execute(docker_cleanup)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -10,3 +10,7 @@ def test_docker_compose_file(docker_compose_file):
 
 def test_docker_compose_project(docker_compose_project_name):
     assert docker_compose_project_name == "pytest{}".format(os.getpid())
+
+
+def test_docker_cleanup(docker_cleanup):
+    assert docker_cleanup == "down -v"


### PR DESCRIPTION
Allows user to override fixture to provide alternate clean-up
command for docker_compose.