### PR TITLE
Drop Python3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
   - docker
 language: python
 python:
-  - '3.5'
   - '3.6'
   - '3.7'
   - '3.8'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.10.0
+- Changes:
+	- Drop Python3.5 support
+
 ## Version 0.9.0
 - Changes:
 	- Add the `docker_cleanup` fixture to allow custom cleanup actions for

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ tests with Docker and [docker-compose](https://docs.docker.com/compose/).
 Specify all necessary containers in a `docker-compose.yml` file and and
 `pytest-docker` will spin them up for the duration of your tests.
 
-This package is tested with Python versions `3.5`, `3.6`, `3.7`, `3.8` and
+This package is tested with Python versions `3.6`, `3.7`, `3.8` and
 `3.9`, and `pytest` version 4, 5 and 6. Python 2 is not supported.
 
 `pytest-docker` was originally created by André Caron.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytest-docker
-version =  0.9.0
+version =  0.10.0
 description = Simple pytest fixtures for Docker and docker-compose based tests
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -13,7 +13,6 @@ author_email = maxim.kovykov@avast.com
 license = MIT
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
@@ -26,7 +25,7 @@ classifiers =
     Operating System :: Microsoft :: Windows
 
 [options]
-python_requires = >= 3.5
+python_requires = >= 3.6
 
 package_dir=
     =src

--- a/src/pytest_docker/plugin.py
+++ b/src/pytest_docker/plugin.py
@@ -83,7 +83,6 @@ class Services:
             )
 
         # This handles messy output that might contain warnings or other text
-        # Added specifically to handle a deprecation warning in Python3.5
         if len(endpoint.split("\n")) > 1:
             endpoint = endpoint.split("\n")[-1]
 


### PR DESCRIPTION
Python 3.5 [reached end-of-life](https://devguide.python.org/#status-of-python-branches) on September 13th, 2020.
Using Python 3.5 raises deprecation warnings in multiple libraries and support will be removed in the future.

I'm not sure if we should consider this a breaking change and raise the version to `1.0.0`.