### PR TITLE
feat: allow container re-use

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,16 +114,16 @@ your tests if you need a particular project name.
 Start all services from the docker compose file (`docker-compose up`).
 After test are finished, shutdown all services (`docker-compose down`).
 
+### `docker_setup`
+
+Get the docker_compose command to be executed for test spawn actions.
+Override this fixture in your tests if you need to change spawn actions.
+Returning anything that would evaluate to False will skip this command.
+
 ### `docker_cleanup`
 
 Get the docker_compose command to be executed for test clean-up actions.
 Override this fixture in your tests if you need to change clean-up actions.
-Returning anything that would evaluate to False will skip this command.
-
-### `docker_spawn`
-
-Get the docker_compose command to be executed for test spawn actions.
-Override this fixture in your tests if you need to change spawn actions.
 Returning anything that would evaluate to False will skip this command.
 
 # Development

--- a/README.md
+++ b/README.md
@@ -116,8 +116,15 @@ After test are finished, shutdown all services (`docker-compose down`).
 
 ### `docker_cleanup`
 
-Get the docker compose command to execute for test clean-up actions. Override
-this fixture in your tests if you need custom clean-up actions.
+Get the docker_compose command to be executed for test clean-up actions.
+Override this fixture in your tests if you need to change clean-up actions.
+Returning anything that would evaluate to False will skip this command.
+
+### `docker_spawn`
+
+Get the docker_compose command to be executed for test spawn actions.
+Override this fixture in your tests if you need to change spawn actions.
+Returning anything that would evaluate to False will skip this command.
 
 # Development
 Use of a virtual environment is recommended. See the

--- a/src/pytest_docker/__init__.py
+++ b/src/pytest_docker/__init__.py
@@ -3,5 +3,15 @@ from .plugin import (
     docker_compose_file,
     docker_compose_project_name,
     docker_ip,
+    docker_setup,
     docker_services,
 )
+
+__all__ = [
+    "docker_cleanup",
+    "docker_compose_file",
+    "docker_compose_project_name",
+    "docker_ip",
+    "docker_setup",
+    "docker_services",
+]

--- a/src/pytest_docker/plugin.py
+++ b/src/pytest_docker/plugin.py
@@ -158,31 +158,31 @@ def docker_cleanup():
     return get_cleanup_command()
 
 
-def get_spawn_command():
+def get_setup_command():
 
     return "up --build -d"
 
 
 @pytest.fixture(scope="session")
-def docker_spawn():
-    """Get the docker_compose command to be executed for test spawn actions.
-    Override this fixture in your tests if you need to change spawn actions.
+def docker_setup():
+    """Get the docker_compose command to be executed for test setup actions.
+    Override this fixture in your tests if you need to change setup actions.
     Returning anything that would evaluate to False will skip this command."""
 
-    return get_spawn_command()
+    return get_setup_command()
 
 
 @contextlib.contextmanager
 def get_docker_services(
-    docker_compose_file, docker_compose_project_name, docker_spawn, docker_cleanup
+    docker_compose_file, docker_compose_project_name, docker_setup, docker_cleanup
 ):
     docker_compose = DockerComposeExecutor(
         docker_compose_file, docker_compose_project_name
     )
 
-    # Spawn containers.
-    if docker_spawn:
-        docker_compose.execute(docker_spawn)
+    # setup containers.
+    if docker_setup:
+        docker_compose.execute(docker_setup)
 
     try:
         # Let test(s) run.
@@ -197,13 +197,13 @@ def get_docker_services(
 def docker_services(
     docker_compose_file,
     docker_compose_project_name,
-    docker_spawn,
+    docker_setup,
     docker_cleanup,
 ):
     """Start all services from a docker compose file (`docker-compose up`).
     After test are finished, shutdown all services (`docker-compose down`)."""
 
     with get_docker_services(
-        docker_compose_file, docker_compose_project_name, docker_spawn, docker_cleanup
+        docker_compose_file, docker_compose_project_name, docker_setup, docker_cleanup
     ) as docker_service:
         yield docker_service

--- a/src/pytest_docker/plugin.py
+++ b/src/pytest_docker/plugin.py
@@ -194,11 +194,16 @@ def get_docker_services(
 
 
 @pytest.fixture(scope="session")
-def docker_services(docker_compose_file, docker_compose_project_name, docker_cleanup):
+def docker_services(
+    docker_compose_file,
+    docker_compose_project_name,
+    docker_spawn,
+    docker_cleanup,
+):
     """Start all services from a docker compose file (`docker-compose up`).
     After test are finished, shutdown all services (`docker-compose down`)."""
 
     with get_docker_services(
-        docker_compose_file, docker_compose_project_name, docker_cleanup
+        docker_compose_file, docker_compose_project_name, docker_spawn, docker_cleanup
     ) as docker_service:
         yield docker_service

--- a/tests/test_docker_services.py
+++ b/tests/test_docker_services.py
@@ -7,6 +7,7 @@ from pytest_docker.plugin import (
     Services,
     get_docker_services,
     get_cleanup_command,
+    get_setup_command,
 )
 
 
@@ -23,6 +24,7 @@ def test_docker_services():
         with get_docker_services(
             "docker-compose.yml",
             docker_compose_project_name="pytest123",
+            docker_setup=get_setup_command(),
             docker_cleanup=get_cleanup_command(),
         ) as services:
             assert isinstance(services, Services)
@@ -76,6 +78,7 @@ def test_docker_services_unused_port():
         with get_docker_services(
             "docker-compose.yml",
             docker_compose_project_name="pytest123",
+            docker_setup=get_setup_command(),
             docker_cleanup=get_cleanup_command(),
         ) as services:
             assert isinstance(services, Services)
@@ -127,6 +130,7 @@ def test_docker_services_failure():
             with get_docker_services(
                 "docker-compose.yml",
                 docker_compose_project_name="pytest123",
+                docker_setup=get_setup_command(),
                 docker_cleanup=get_cleanup_command(),
             ):
                 pass

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -15,5 +15,5 @@ def test_docker_compose_project(docker_compose_project_name):
 def test_docker_cleanup(docker_cleanup):
     assert docker_cleanup == "down -v"
 
-def test_docker_spawn(docker_spawn):
-    assert docker_spawn == "up --build -d"
+def test_docker_setup(docker_setup):
+    assert docker_setup == "up --build -d"

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -14,3 +14,6 @@ def test_docker_compose_project(docker_compose_project_name):
 
 def test_docker_cleanup(docker_cleanup):
     assert docker_cleanup == "down -v"
+
+def test_docker_spawn(docker_spawn):
+    assert docker_spawn == "up --build -d"


### PR DESCRIPTION
If the spawn and cleanup commands are skipped by overriding the fixture
commands to "", None, or False then existing containers can be left
around.

Having this as a native feature would be much cleaner than how I'm currently managing this. Thank you for all the work on this project, I've used it in many others with great success :)