### PR TITLE
Add support for Docker Compose v2 and relax dependency over `docker-compose` PIP package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changes:
   installing `pytest-docker` with PIP. If you want to, you install
   `pytest-docker` with the `docker-compose-v1` extra (`pip install
   pytest-docker[docker-compose-v1]`).
+- Add support for Docker Compose v2 via a new pytest fixture,
+  `docker_compose_command` that should return `docker compose`.
 
 ## Version 0.12.0
 Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+Changes:
+- Default behavior is not to install `docker-compose` at all when
+  installing `pytest-docker` with PIP. If you want to, you install
+  `pytest-docker` with the `docker-compose-v1` extra (`pip install
+  pytest-docker[docker-compose-v1]`).
+
 ## Version 0.12.0
 Changes:
 - Add `docker_setup` fixture to allow custom setup actions for docker-compose

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ environment to ensure that it is available during tests. This will prevent
 potential dependency conflicts that can occur when the system wide
 `docker-compose` is used in tests.
 
+The default behavior is not to install `docker-compose` at all. If you
+want to, you install `pytest-docker` with the `docker-compose` extra,
+you can use the following command:
+
+```
+pip install pytest-docker[docker-compose-v1]
+```
+
 
 # Usage
 Here is an example of a test that depends on a HTTP service.

--- a/README.md
+++ b/README.md
@@ -25,13 +25,23 @@ potential dependency conflicts that can occur when the system wide
 `docker-compose` is used in tests.
 
 The default behavior is not to install `docker-compose` at all. If you
-want to, you install `pytest-docker` with the `docker-compose` extra,
-you can use the following command:
+want to, you install `pytest-docker` with the `docker-compose-v1`
+extra, you can use the following command:
 
 ```
 pip install pytest-docker[docker-compose-v1]
 ```
 
+## Docker Compose v2 compatiblity
+
+This version of `pytest-docker` is compatible with Docker Compose v1
+(legacy) and Docker Compose v2 if you have
+[`compose-switch`](https://github.com/docker/compose-switch)
+installed.
+
+If you want to use the real Docker Compose v2, it has to be installed
+system wide ([more
+information](https://github.com/docker/compose#linux)).
 
 # Usage
 Here is an example of a test that depends on a HTTP service.
@@ -133,6 +143,12 @@ Returning anything that would evaluate to False will skip this command.
 Get the docker_compose command to be executed for test clean-up actions.
 Override this fixture in your tests if you need to change clean-up actions.
 Returning anything that would evaluate to False will skip this command.
+
+### `docker_compose_command`
+
+Docker Compose command to use to execute Dockers. Default is to use
+Docker Compose v1 (command is `docker-compose`). If you want to use
+Docker Compose v2, change this fixture to return `docker compose`.
 
 # Development
 Use of a virtual environment is recommended. See the

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ environment to ensure that it is available during tests. This will prevent
 potential dependency conflicts that can occur when the system wide
 `docker-compose` is used in tests.
 
-The default behavior is not to install `docker-compose` at all. If you
+The default behavior is not to install `docker-compose` with `pytest-docker`. If you
 want to, you install `pytest-docker` with the `docker-compose-v1`
-extra, you can use the following command:
+extra. You can use the following command:
 
 ```
 pip install pytest-docker[docker-compose-v1]
@@ -34,14 +34,14 @@ pip install pytest-docker[docker-compose-v1]
 
 ## Docker Compose v2 compatiblity
 
-This version of `pytest-docker` is compatible with Docker Compose v1
-(legacy) and Docker Compose v2 if you have
+`pytest-docker` will work with Docker Compose v2 out of the box if
 [`compose-switch`](https://github.com/docker/compose-switch)
-installed.
+is installed.
 
 If you want to use the real Docker Compose v2, it has to be installed
-system wide ([more
-information](https://github.com/docker/compose#linux)).
+system wide ([more information](https://github.com/docker/compose#linux))
+and you have to modify the [`docker-compose-command`](#docker_compose_command)
+fixture (this behavior might change in the future versions).
 
 # Usage
 Here is an example of a test that depends on a HTTP service.
@@ -132,6 +132,12 @@ your tests if you need a particular project name.
 Start all services from the docker compose file (`docker-compose up`).
 After test are finished, shutdown all services (`docker-compose down`).
 
+### `docker_compose_command`
+
+Docker Compose command to use to execute Dockers. Default is to use
+Docker Compose v1 (command is `docker-compose`). If you want to use
+Docker Compose v2, change this fixture to return `docker compose`.
+
 ### `docker_setup`
 
 Get the docker_compose command to be executed for test spawn actions.
@@ -144,11 +150,6 @@ Get the docker_compose command to be executed for test clean-up actions.
 Override this fixture in your tests if you need to change clean-up actions.
 Returning anything that would evaluate to False will skip this command.
 
-### `docker_compose_command`
-
-Docker Compose command to use to execute Dockers. Default is to use
-Docker Compose v1 (command is `docker-compose`). If you want to use
-Docker Compose v2, change this fixture to return `docker compose`.
 
 # Development
 Use of a virtual environment is recommended. See the

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,10 @@ packages=pytest_docker
 install_requires =
     pytest >=4.0, <8.0
     attrs >=19, <22
-    docker-compose >=1.27.3, <2.0
 
 [options.extras_require]
+docker-compose-v1 =
+    docker-compose >=1.27.3, <2.0
 tests =
     requests >=2.22.0, <3.0
     pytest-pylint >=0.14.1, <1.0

--- a/src/pytest_docker/__init__.py
+++ b/src/pytest_docker/__init__.py
@@ -1,5 +1,6 @@
 from .plugin import (
     docker_cleanup,
+    docker_compose_command,
     docker_compose_file,
     docker_compose_project_name,
     docker_ip,

--- a/tests/test_docker_services.py
+++ b/tests/test_docker_services.py
@@ -22,6 +22,7 @@ def test_docker_services():
 
         # The fixture is a context-manager.
         with get_docker_services(
+            "docker-compose",
             "docker-compose.yml",
             docker_compose_project_name="pytest123",
             docker_setup=get_setup_command(),
@@ -76,6 +77,7 @@ def test_docker_services_unused_port():
 
         # The fixture is a context-manager.
         with get_docker_services(
+            "docker-compose",
             "docker-compose.yml",
             docker_compose_project_name="pytest123",
             docker_setup=get_setup_command(),
@@ -128,6 +130,7 @@ def test_docker_services_failure():
         # The fixture is a context-manager.
         with pytest.raises(Exception) as exc:
             with get_docker_services(
+                "docker-compose",
                 "docker-compose.yml",
                 docker_compose_project_name="pytest123",
                 docker_setup=get_setup_command(),
@@ -158,7 +161,9 @@ def test_wait_until_responsive_timeout():
 
     with mock.patch("time.sleep") as sleep:
         docker_compose = DockerComposeExecutor(
-            compose_files="docker-compose.yml", compose_project_name="pytest123"
+            compose_command="docker-compose",
+            compose_files="docker-compose.yml",
+            compose_project_name="pytest123",
         )
         services = Services(docker_compose)
         with pytest.raises(Exception) as exc:

--- a/tests/test_dockercomposeexecutor.py
+++ b/tests/test_dockercomposeexecutor.py
@@ -6,7 +6,9 @@ from pytest_docker.plugin import DockerComposeExecutor
 
 
 def test_execute():
-    docker_compose = DockerComposeExecutor("docker-compose.yml", "pytest123")
+    docker_compose = DockerComposeExecutor(
+        "docker-compose", "docker-compose.yml", "pytest123"
+    )
     with mock.patch("subprocess.check_output") as check_output:
         docker_compose.execute("up")
         assert check_output.call_args_list == [
@@ -18,9 +20,24 @@ def test_execute():
         ]
 
 
+def test_execute_docker_compose_v2():
+    docker_compose = DockerComposeExecutor(
+        "docker compose", "docker-compose.yml", "pytest123"
+    )
+    with mock.patch("subprocess.check_output") as check_output:
+        docker_compose.execute("up")
+        assert check_output.call_args_list == [
+            mock.call(
+                'docker compose -f "docker-compose.yml" -p "pytest123" up',
+                shell=True,
+                stderr=subprocess.STDOUT,
+            )
+        ]
+
+
 def test_pypath_compose_files():
     compose_file = py.path.local("/tmp/docker-compose.yml")
-    docker_compose = DockerComposeExecutor(compose_file, "pytest123")
+    docker_compose = DockerComposeExecutor("docker-compose", compose_file, "pytest123")
     with mock.patch("subprocess.check_output") as check_output:
         docker_compose.execute("up")
         assert check_output.call_args_list == [
@@ -34,7 +51,7 @@ def test_pypath_compose_files():
 
 def test_multiple_compose_files():
     docker_compose = DockerComposeExecutor(
-        ["docker-compose.yml", "other-compose.yml"], "pytest123"
+        "docker-compose", ["docker-compose.yml", "other-compose.yml"], "pytest123"
     )
     with mock.patch("subprocess.check_output") as check_output:
         docker_compose.execute("up")

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -17,3 +17,6 @@ def test_docker_cleanup(docker_cleanup):
 
 def test_docker_setup(docker_setup):
     assert docker_setup == "up --build -d"
+
+def test_docker_compose_comand(docker_compose_command):
+    assert docker_compose_command == "docker-compose"


### PR DESCRIPTION
This is a first attempt to provide Docker Compose v2 support to `pytest-docker`. Default is to keep using Docker Compose v1, but users can change to Docker Compose v2 by overriding the `docker_compose_command` fixture to return `"docker compose"` string.

This also remove the strict dependency over `docker-compose` PIP package. The default will be to _not_ install `docker-compose` at all to rely on the version installed on the system. If you want to install `docker-compose` package along with `docker-pytest`, the `docker-pytest[docker-compose-v1]` extra is available.

