### PR TITLE
Use tox to declare the test matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9"]
-        pytest-version: [4, 5, 6]
 
     steps:
       - uses: actions/checkout@v2
@@ -16,18 +15,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies, pytest ${{ matrix.pytest-version }}
+      - name: Install tox
         run: |
-          python -m pip install --upgrade pip setuptools
-          pip install pytest==${{ matrix.pytest-version }}
-          pip install ".[tests]"
-      - name: Build image
+          python -m pip install --upgrade pip tox
+      - name: Run tox testenvs
+        env:
+          TOX_SKIP_ENV: "^((?!py${{ matrix.python-version }}).)*$"
         run: |
-          docker-compose -f tests/docker-compose.yml pull
-          docker-compose -f tests/docker-compose.yml build
-      - name: Run tests
-        run: |
-          pytest -c setup.cfg
-      - name: Stop Docker compose
-        run: |
-          docker-compose -f tests/docker-compose.yml down
+          tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ package_dir=
 packages=pytest_docker
 
 install_requires =
-    pytest >=4.0, <7.0
+    pytest >=4, <8
     attrs >=19, <22
     docker-compose >=1.27.3, <2.0
 
@@ -42,10 +42,6 @@ tests =
     requests >=2.22.0, <3.0
     pytest-pylint >=0.14.1, <1.0
     pytest-pycodestyle >=2.0.0, <3.0
-
-[tool:pytest]
-addopts = --verbose --pylint-rcfile=setup.cfg
-# --pylint --pycodestyle
 
 [pycodestyle]
 max-line-length=120

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,29 @@
+[tox]
+envlist =
+    py{3.6,3.7,3.8,3.9}-pytest{4,5,6,7}
+
+[testenv]
+extras =
+    tests
+deps =
+    pytest4: pytest~=4.0
+    pytest5: pytest~=5.0
+    pytest6: pytest~=6.0
+    pytest7: pytest~=7.0
+basepython =
+    py3.6: python3.6
+    py3.7: python3.7
+    py3.8: python3.8
+    py3.9: python3.9
+setenv =
+    COMPOSE_FILE=tests/docker-compose.yml
+commands_pre =
+    docker-compose build --pull
+commands =
+    pytest
+commands_post =
+    docker-compose down
+
+[pytest]
+addopts = --verbose --pylint-rcfile=setup.cfg
+# --pylint --pycodestyle


### PR DESCRIPTION
This eases the burden of locally testing the plugin across
all supported python and pytest versions, and will simplify
some future exclusions in the matrix (e.g. pytest<6.2
incompatibility with python-3.10)

CI jobs are simplified to be agnostic of the underlying test matrix,
restricting each job to the python versions they explicitly
setup with a negative lookup in the TOX_SKIP_ENV variable.
Each job will be larger due to less venv fragmentation but they
will be collectively more efficient thanks to the reutilization of
the pulled and built docker images.

Also introduce support for pytest-7 and move pytest configuration to the
new tox.ini file, as this is preferable instead of the current setup.cfg
https://docs.pytest.org/en/6.2.x/reference.html#configuration-options