### PR TITLE
Abide by PEP-517

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -18,10 +18,10 @@ jobs:
           python-version: 3.9
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel twine
+          python -m pip install --upgrade pip build twine
       - name: Build distribution packages
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
       - name: Build and publish
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,10 @@ tests =
     pytest-pylint >=0.14.1, <1.0
     pytest-pycodestyle >=2.0.0, <3.0
 
+[options.entry_points]
+pytest11 =
+    docker = pytest_docker
+
 [tool:pytest]
 addopts = --verbose --pylint-rcfile=setup.cfg
 # --pylint --pycodestyle

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
 from setuptools import setup
 
-setup(
-    setup_requires=["wheel >= 0.32"],
-    entry_points={"pytest11": ["docker = pytest_docker"]},
-)
+setup()


### PR DESCRIPTION
Move all packaging options to setup.cfg and building
requirements to pyproject.toml.

An empty setup.py is left in place for compatibility with
legacy building environments.

Use PyPA's https://pypi.org/project/build/ as the new PEP-517
building frontend in the release CI workflows, which will
already craft both a source and a binary distribution.

See https://www.python.org/dev/peps/pep-0517/