### PR TITLE
Pytest-7, Compose-2, Python-3.10, PEP-517, and tox

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -18,10 +18,10 @@ jobs:
           python-version: 3.9
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel twine
+          python -m pip install --upgrade pip build twine
       - name: Build distribution packages
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
       - name: Build and publish
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,10 +24,10 @@ jobs:
         run: |
           tox
       - name: Install Docker Compose v2
-        run: |
-          mkdir -p ~/.docker/cli-plugins/
-          curl -SL https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
-          [[ "$(docker compose version)" = "Docker Compose version v2.2.3" ]] || exit 2
+        uses: ndeloof/install-compose-action@v0.0.1
+        with:
+          version: latest
+          legacy: true
       - name: Run compose-v2 testenvs
         env:
           TOX_SKIP_ENV: "^((?!py${{ matrix.python-version }}-pytest.-compose2).)*$"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install Docker Compose v2
+        run: |
+          mkdir -p ~/.docker/cli-plugins/
+          curl -SL https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
+          [[ "$(docker compose version)" = "Docker Compose version v2.2.3" ]] || exit 2
       - name: Install tox
         run: |
           python -m pip install --upgrade pip tox

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,6 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9"]
-        pytest-version: [4, 5, 6, 7]
 
     steps:
       - uses: actions/checkout@v2
@@ -16,18 +15,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies, pytest ${{ matrix.pytest-version }}
+      - name: Install tox
         run: |
-          python -m pip install --upgrade pip setuptools
-          pip install pytest==${{ matrix.pytest-version }}
-          pip install ".[tests]"
-      - name: Build image
+          python -m pip install --upgrade pip tox
+      - name: Run tox testenvs
+        env:
+          TOX_SKIP_ENV: "^((?!py${{ matrix.python-version }}).)*$"
         run: |
-          docker-compose -f tests/docker-compose.yml pull
-          docker-compose -f tests/docker-compose.yml build
-      - name: Run tests
-        run: |
-          pytest -c setup.cfg
-      - name: Stop Docker compose
-        run: |
-          docker-compose -f tests/docker-compose.yml down
+          tox

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,16 +15,21 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install tox
+        run: |
+          python -m pip install --upgrade pip tox
+      - name: Run compose-v1 testenvs
+        env:
+          TOX_SKIP_ENV: "^((?!py${{ matrix.python-version }}-pytest.-compose1).)*$"
+        run: |
+          tox
       - name: Install Docker Compose v2
         run: |
           mkdir -p ~/.docker/cli-plugins/
           curl -SL https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
           [[ "$(docker compose version)" = "Docker Compose version v2.2.3" ]] || exit 2
-      - name: Install tox
-        run: |
-          python -m pip install --upgrade pip tox
-      - name: Run tox testenvs
+      - name: Run compose-v2 testenvs
         env:
-          TOX_SKIP_ENV: "^((?!py${{ matrix.python-version }}).)*$"
+          TOX_SKIP_ENV: "^((?!py${{ matrix.python-version }}-pytest.-compose2).)*$"
         run: |
           tox

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9"]
-        pytest-version: [4, 5, 6]
+        pytest-version: [4, 5, 6, 7]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+Changes:
+- Default behavior is not to install `docker-compose` at all when
+  installing `pytest-docker` with PIP. If you want to, you install
+  `pytest-docker` with the `docker-compose-v1` extra (`pip install
+  pytest-docker[docker-compose-v1]`).
 ## Version 0.10.3
 Changes:
 - Ensure that Docker cleanup is executed even with after tests have failed

--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ environment to ensure that it is available during tests. This will prevent
 potential dependency conflicts that can occur when the system wide
 `docker-compose` is used in tests.
 
+The default behavior is not to install `docker-compose` at all. If you
+want to, you install `pytest-docker` with the `docker-compose` extra,
+you can use the following command:
+
+```
+pip install pytest-docker[docker-compose-v1]
+```
+
 
 # Usage
 Here is an example of a test that depends on a HTTP service.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,10 +43,6 @@ tests =
     pytest-pylint >=0.14.1, <1.0
     pytest-pycodestyle >=2.0.0, <3.0
 
-[tool:pytest]
-addopts = --verbose --pylint-rcfile=setup.cfg
-# --pylint --pycodestyle
-
 [pycodestyle]
 max-line-length=120
 ignore=E4,E7,W3

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ package_dir=
 packages=pytest_docker
 
 install_requires =
-    pytest >=4.0, <7.0
+    pytest >=4.0, <8.0
     attrs >=19, <22
     docker-compose >=1.27.3, <2.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,10 @@ packages=pytest_docker
 install_requires =
     pytest >=4.0, <8.0
     attrs >=19, <22
-    docker-compose >=1.27.3, <2.0
 
 [options.extras_require]
+docker-compose-v1 =
+    docker-compose >=1.27.3, <2.0
 tests =
     requests >=2.22.0, <3.0
     pytest-pylint >=0.14.1, <1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,10 @@ tests =
     pytest-pylint >=0.14.1, <1.0
     pytest-pycodestyle >=2.0.0, <3.0
 
+[options.entry_points]
+pytest11 =
+    docker = pytest_docker
+
 [pycodestyle]
 max-line-length=120
 ignore=E4,E7,W3

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
 from setuptools import setup
 
-setup(
-    setup_requires=["wheel >= 0.32"],
-    entry_points={"pytest11": ["docker = pytest_docker"]},
-)
+setup()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,29 @@
+[tox]
+envlist =
+    py{3.6,3.7,3.8,3.9}-pytest{4,5,6,7}
+
+[testenv]
+extras =
+    tests
+deps =
+    pytest4: pytest~=4.0
+    pytest5: pytest~=5.0
+    pytest6: pytest~=6.0
+    pytest7: pytest~=7.0
+basepython =
+    py3.6: python3.6
+    py3.7: python3.7
+    py3.8: python3.8
+    py3.9: python3.9
+setenv =
+    COMPOSE_FILE=tests/docker-compose.yml
+commands_pre =
+    docker-compose build --pull
+commands =
+    pytest
+commands_post =
+    docker-compose down
+
+[pytest]
+addopts = --verbose --pylint-rcfile=setup.cfg
+# --pylint --pycodestyle

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,11 @@
 [tox]
+isolated_build = True
 envlist =
     py{3.6,3.7,3.8,3.9}-pytest{4,5}
     py{3.6,3.7,3.8,3.9,3.10}-pytest{6,7}
+
+[testenv:.package]
+basepython = python3
 
 [testenv]
 extras =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    py{3.6,3.7,3.8,3.9}-pytest{4,5,6,7}
+    py{3.6,3.7,3.8,3.9}-pytest{4,5}
+    py{3.6,3.7,3.8,3.9,3.10}-pytest{6,7}
 
 [testenv]
 extras =
@@ -15,6 +16,7 @@ basepython =
     py3.7: python3.7
     py3.8: python3.8
     py3.9: python3.9
+    py3.10: python3.10
 setenv =
     COMPOSE_FILE=tests/docker-compose.yml
 commands_pre =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 isolated_build = True
 envlist =
-    py{3.6,3.7,3.8,3.9}-pytest{4,5}
-    py{3.6,3.7,3.8,3.9,3.10}-pytest{6,7}
+    py{3.6,3.7,3.8,3.9}-pytest{4,5}-compose{1,2}
+    py{3.6,3.7,3.8,3.9,3.10}-pytest{6,7}-compose{1,2}
 
 [testenv:.package]
 basepython = python3
@@ -10,6 +10,9 @@ basepython = python3
 [testenv]
 extras =
     tests
+    compose1: tests,docker-compose-v1
+allowlist_externals =
+    compose2: docker-compose
 deps =
     pytest4: pytest~=4.0
     pytest5: pytest~=5.0
@@ -24,6 +27,7 @@ basepython =
 setenv =
     COMPOSE_FILE=tests/docker-compose.yml
 commands_pre =
+    docker-compose --version
     docker-compose build --pull
 commands =
     pytest


### PR DESCRIPTION
This is a mash-up cherry-picking commits from #72 #74 #75 and #76 to demonstrate the power of introducing tox. And also solving all the merge conflicts that they will cause each other.

Also introduces support for Python-3.10.

If merged, this should better be NOT squashed so as to differentiate the commits from the all the involved authors.