### PR TITLE
chore: support the `unix:` scheme in `DOCKER_HOST`

### DIFF
--- a/src/pytest_docker/plugin.py
+++ b/src/pytest_docker/plugin.py
@@ -33,7 +33,7 @@ def get_docker_ip():
     # When talking to the Docker daemon via a UNIX socket, route all TCP
     # traffic to docker containers via the TCP loopback interface.
     docker_host = os.environ.get("DOCKER_HOST", "").strip()
-    if not docker_host:
+    if not docker_host or docker_host.startswith("unix://"):
         return "127.0.0.1"
 
     match = re.match(r"^tcp://(.+?):\d+$", docker_host)

--- a/tests/test_docker_ip.py
+++ b/tests/test_docker_ip.py
@@ -16,6 +16,12 @@ def test_docker_ip_remote():
         assert get_docker_ip() == "1.2.3.4"
 
 
+def test_docker_ip_unix():
+    environ = {"DOCKER_HOST": "unix:///run/user/1000/podman/podman.sock"}
+    with mock.patch("os.environ", environ):
+        assert get_docker_ip() == "127.0.0.1"
+
+
 @pytest.mark.parametrize("docker_host", ["http://1.2.3.4:2376"])
 def test_docker_ip_remote_invalid(docker_host):
     environ = {"DOCKER_HOST": docker_host}


### PR DESCRIPTION
In get_docker_ip(), if `DOCKER_HOST` is using the `unix:` scheme then
return "127.0.0.1"