### PR TITLE
Remove attrs constraint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ packages=pytest_docker
 
 install_requires =
     pytest >=4.0, <8.0
-    attrs >=19, <22
 
 [options.extras_require]
 docker-compose-v1 =


### PR DESCRIPTION
attrs is required by pytest but we should be able to remove the <22 constraint since it isn't directly used by this package

```
pytest-docker==1.0.0
  - pytest [required: >=4.0,<8.0, installed: 7.1.2]
    - attrs [required: >=19.2.0, installed: 22.1.0]
    - iniconfig [required: Any, installed: 1.1.1]
    - packaging [required: Any, installed: 21.3]
      - pyparsing [required: >=2.0.2,!=3.0.5, installed: 3.0.9]
    - pluggy [required: >=0.12,<2.0, installed: 1.0.0]
    - py [required: >=1.8.2, installed: 1.11.0]
    - tomli [required: >=1.0.0, installed: 2.0.1]
pytest-pycodestyle==2.3.0
  - pycodestyle [required: Any, installed: 2.9.1]
  - pytest [required: >=7.0, installed: 7.1.2]
    - attrs [required: >=19.2.0, installed: 22.1.0]
    - iniconfig [required: Any, installed: 1.1.1]
    - packaging [required: Any, installed: 21.3]
      - pyparsing [required: >=2.0.2,!=3.0.5, installed: 3.0.9]
    - pluggy [required: >=0.12,<2.0, installed: 1.0.0]
    - py [required: >=1.8.2, installed: 1.11.0]
    - tomli [required: >=1.0.0, installed: 2.0.1]
pytest-pylint==0.18.0
  - pylint [required: >=2.3.0, installed: 2.14.5]
    - astroid [required: >=2.11.6,<=2.12.0-dev0, installed: 2.11.7]
      - lazy-object-proxy [required: >=1.4.0, installed: 1.7.1]
      - setuptools [required: >=20.0, installed: 58.1.0]
      - wrapt [required: >=1.11,<2, installed: 1.14.1]
    - dill [required: >=0.2, installed: 0.3.5.1]
    - isort [required: >=4.2.5,<6, installed: 5.10.1]
    - mccabe [required: >=0.6,<0.8, installed: 0.7.0]
    - platformdirs [required: >=2.2.0, installed: 2.5.2]
    - tomli [required: >=1.1.0, installed: 2.0.1]
    - tomlkit [required: >=0.10.1, installed: 0.11.1]
  - pytest [required: >=5.4, installed: 7.1.2]
    - attrs [required: >=19.2.0, installed: 22.1.0]

```