### PR TITLE
feat: raise a more specific exception on timeout

### DIFF
--- a/src/pytest_docker/plugin.py
+++ b/src/pytest_docker/plugin.py
@@ -10,6 +10,16 @@ import attr
 import pytest
 
 
+class PytestDockerError(Exception):
+    """Base pytest-docker exception."""
+
+
+class ServiceTimeoutError(PytestDockerError):
+    """
+    Timed out while waiting for Docker service(s).
+    """
+
+
 def execute(command, success_codes=(0,)):
     """Run a shell command."""
     try:
@@ -105,7 +115,7 @@ class Services:
             time.sleep(pause)
             now = clock()
 
-        raise Exception("Timeout reached while waiting on service!")
+        raise ServiceTimeoutError("Timeout reached while waiting on service!")
 
 
 def str_to_list(arg):


### PR DESCRIPTION
This provides a narrower exception to catch when calling `wait_until_responsive`.

Context: when an entire testsuite relies on a service, I'd like to call `pytest.exit()` if it times out so that a useful error message is displayed for the user instead of failing the fixture setup for all tests and producing a wall of text.