### PR TITLE
Adjust docker port resolution to be more tolerant (podman-compose)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pytest-docker
-version =  2.0.0
+version =  2.0.1
 description = Simple pytest fixtures for Docker and Docker Compose based tests
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/src/pytest_docker/plugin.py
+++ b/src/pytest_docker/plugin.py
@@ -87,7 +87,7 @@ class Services:
             endpoint = endpoint.split("\n")[-1]
 
         # Usually, the IP address here is 0.0.0.0, so we don't use it.
-        match = int(endpoint.split(":", 1)[1])
+        match = int(endpoint.split(":", 1)[-1])
 
         # Store it in cache in case we request it multiple times.
         self._services.setdefault(service, {})[container_port] = match


### PR DESCRIPTION
### Summary

Tiny refactor which should not impact existing behaviour apart from being more tolerant when using `podman-compose`.

### Details

When using `podman-compose` instead of `docker-compose`, the following line fails:

```py
match = int(endpoint.split(":", 1)[1])
```

The reason seems to be that the endpoint variable is just the port (e.g. `"9200"`) when using `podman-compose`.

The modification (below) retains the original behaviour while being more tolerant of the host being missing.

```py
match = int(endpoint.split(":", 1)[-1])
```