### PR TITLE
Allow multiple setup/cleanup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,13 @@ Docker Compose V1, change this fixture to return `docker-compose`.
 
 ### `docker_setup`
 
-Get the docker_compose command to be executed for test spawn actions.
+Get the list of docker_compose commands to be executed for test spawn actions.
 Override this fixture in your tests if you need to change spawn actions.
 Returning anything that would evaluate to False will skip this command.
 
 ### `docker_cleanup`
 
-Get the docker_compose command to be executed for test clean-up actions.
+Get the list of docker_compose commands to be executed for test clean-up actions.
 Override this fixture in your tests if you need to change clean-up actions.
 Returning anything that would evaluate to False will skip this command.
 

--- a/src/pytest_docker/plugin.py
+++ b/src/pytest_docker/plugin.py
@@ -162,8 +162,7 @@ def docker_compose_project_name():
 
 
 def get_cleanup_command():
-
-    return "down -v"
+    return ["down -v"]
 
 
 @pytest.fixture(scope=containers_scope)
@@ -176,8 +175,7 @@ def docker_cleanup():
 
 
 def get_setup_command():
-
-    return "up --build -d"
+    return ["up --build -d"]
 
 
 @pytest.fixture(scope=containers_scope)
@@ -203,7 +201,11 @@ def get_docker_services(
 
     # setup containers.
     if docker_setup:
-        docker_compose.execute(docker_setup)
+        # Maintain backwards compatibility with the string format.
+        if isinstance(docker_setup, str):
+            docker_setup = [docker_setup]
+        for command in docker_setup:
+            docker_compose.execute(command)
 
     try:
         # Let test(s) run.
@@ -211,7 +213,11 @@ def get_docker_services(
     finally:
         # Clean up.
         if docker_cleanup:
-            docker_compose.execute(docker_cleanup)
+            # Maintain backwards compatibility with the string format.
+            if isinstance(docker_cleanup, str):
+                docker_cleanup = [docker_cleanup]
+            for command in docker_cleanup:
+                docker_compose.execute(command)
 
 
 @pytest.fixture(scope=containers_scope)

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -13,11 +13,13 @@ def test_docker_compose_project(docker_compose_project_name):
 
 
 def test_docker_cleanup(docker_cleanup):
-    assert docker_cleanup == "down -v"
+    assert docker_cleanup == ["down -v"]
+
 
 
 def test_docker_setup(docker_setup):
-    assert docker_setup == "up --build -d"
+    assert docker_setup == ["up --build -d"]
+
 
 
 def test_docker_compose_command(docker_compose_command):


### PR DESCRIPTION
Implement ability to supply multiple commands for `docker_setup` and `docker_cleanup`, while maintaining backwards compatibility.

- [x] Implement new feature
- [x] Maintain old functionality
- [x] Add tests
- [x] Update docs