### PR TITLE
Update docs and tests for supported versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         pytest-version: [4, 5, 6, 7]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ tests with Docker and [Docker Compose](https://docs.docker.com/compose/).
 Specify all necessary containers in a `docker-compose.yml` file and and
 `pytest-docker` will spin them up for the duration of your tests.
 
-This package is tested with Python versions `3.6`, `3.7`, `3.8` and
-`3.9`, and `pytest` version 4, 5 and 6. Python 2 is not supported.
+This package is tested with Python versions `3.8`, `3.9`, `3.10`, `3.11`, `3.12`, 
+and `pytest` version 4, 5, 6, and 7. Python 2 is not supported.
 
 `pytest-docker` was originally created by André Caron.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,11 +13,11 @@ author_email = maxim.kovykov@avast.com
 license = MIT
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     License :: OSI Approved :: MIT License
     Topic :: Utilities
     Intended Audience :: Developers
@@ -26,7 +26,7 @@ classifiers =
     Operating System :: Microsoft :: Windows
 
 [options]
-python_requires = >= 3.6
+python_requires = >= 3.8
 
 package_dir=
     =src


### PR DESCRIPTION
Updated docs to reflect supported versions.

Changes had been made in #74, but not reflected in README and setup.cfg. The GitHub test workflow already checked for Python (3.7, 3.8, 3.9, 3.10, 3.11) and pytest (4, 5, 6, 7), but not all of these were reflected in README and setup.cfg.

This PR also drops testing for Python 3.7, which has reached [end of life](https://devguide.python.org/versions/), and adds testing for the newly released [Python 3.12](https://www.python.org/downloads/release/python-3120/).