### PR TITLE
chore: Python 3.13 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         pytest-version: [4, 5, 6, 7, 8]
 
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,11 +23,11 @@ jobs:
           pip install ".[tests]"
       - name: Build image
         run: |
-          docker-compose -f tests/docker-compose.yml pull
-          docker-compose -f tests/docker-compose.yml build
+          docker compose -f tests/docker-compose.yml pull
+          docker compose -f tests/docker-compose.yml build
       - name: Run tests
         run: |
           pytest -c setup.cfg
       - name: Stop Docker compose
         run: |
-          docker-compose -f tests/docker-compose.yml down
+          docker compose -f tests/docker-compose.yml down

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     License :: OSI Approved :: MIT License
     Topic :: Utilities
     Intended Audience :: Developers


### PR DESCRIPTION
- Added Python 3.13 support
- Fixed tests workflow to use `docker compose` instead of `docker-compose`