### PR TITLE
Fix non-existing docker_setup_command into docker_setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ def docker_compose_project_name() -> str:
 
 # Stop the stack before starting a new one
 @pytest.fixture(scope="session")
-def docker_setup_command():
+def docker_setup():
     return ["down -v", "up --build -d"]
 ```
 


### PR DESCRIPTION
The proper name for the fixture, reading the documentation and doing some local testing, should be `docker_setup`.

The Available fixtures seem to be correct, but the example is not.