### PR TITLE
Make the plugin.Services class available at the base module level for easier typing

### DIFF
--- a/src/pytest_docker/__init__.py
+++ b/src/pytest_docker/__init__.py
@@ -8,6 +8,7 @@ from .plugin import (
     docker_ip,
     docker_services,
     docker_setup,
+    Services,
 )
 
 __all__ = [
@@ -18,6 +19,7 @@ __all__ = [
     "docker_setup",
     "docker_cleanup",
     "docker_services",
+    "Services",
 ]
 
 


### PR DESCRIPTION
Hello, thank you for this plugin! One minor issue with using typed code on my end is that I have to use
```python
def test_function(docker_services: pytest_docker.plugin.Services) -> None:
    ...
``` 
because the [Services](https://github.com/avast/pytest-docker/blob/60c4c7cb224c245e2850010c2d25fc6cd5256ab4/src/pytest_docker/plugin.py#L63) class itself wasn’t imported into the main module. This change adds the class name which should make typing a little easier…