### PR TITLE
Use `--wait` in the default setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ def test_status_code(http_service):
     assert response.status_code == status
 ```
 
+> The default `docker_setup` command includes `--wait`, which respects either the
+> image `HEALTHCHECK` or the compose `healthcheck`. Generally, if those
+> are configured properly, `wait_until_responsive` should not be required. 
+
 By default, this plugin will try to open `docker-compose.yml` in your
 `tests` directory. If you need to use a custom location, override the
 `docker_compose_file` fixture inside your `conftest.py` file:
@@ -138,7 +142,7 @@ def docker_compose_project_name() -> str:
 # Stop the stack before starting a new one
 @pytest.fixture(scope="session")
 def docker_setup():
-    return ["down -v", "up --build -d"]
+    return ["down -v", "up --build --wait"]
 ```
 
 

--- a/src/pytest_docker/plugin.py
+++ b/src/pytest_docker/plugin.py
@@ -179,7 +179,7 @@ def docker_cleanup() -> Union[List[str], str]:
 
 
 def get_setup_command() -> Union[List[str], str]:
-    return ["up --build -d"]
+    return ["up --build --wait"]
 
 
 @pytest.fixture(scope=containers_scope)

--- a/tests/test_docker_services.py
+++ b/tests/test_docker_services.py
@@ -49,7 +49,7 @@ def test_docker_services() -> None:
     # Both should have been called.
     assert check_output.call_args_list == [
         mock.call(
-            'docker compose -f "docker-compose.yml" -p "pytest123" up --build -d',
+            'docker compose -f "docker-compose.yml" -p "pytest123" up --build --wait',
             stderr=subprocess.STDOUT,
             shell=True,
         ),
@@ -100,7 +100,7 @@ def test_docker_services_unused_port() -> None:
     assert check_output.call_args_list == [
         mock.call(
             'docker compose -f "docker-compose.yml" -p "pytest123" '
-            "up --build -d",  # pylint: disable:=implicit-str-concat
+            'up --build --wait',  # pylint: disable:=implicit-str-concat
             shell=True,
             stderr=subprocess.STDOUT,
         ),
@@ -147,7 +147,7 @@ def test_docker_services_failure() -> None:
     assert check_output.call_args_list == [
         mock.call(
             'docker compose -f "docker-compose.yml" -p "pytest123" '
-            "up --build -d",  # pylint: disable:=implicit-str-concat
+            "up --build --wait",  # pylint: disable:=implicit-str-concat
             shell=True,
             stderr=subprocess.STDOUT,
         )
@@ -188,7 +188,7 @@ def test_single_commands() -> None:
             "docker compose",
             "docker-compose.yml",
             docker_compose_project_name="pytest123",
-            docker_setup="up --build -d",
+            docker_setup="up --build --wait",
             docker_cleanup="down -v",
         ) as services:
             assert isinstance(services, Services)
@@ -212,7 +212,7 @@ def test_single_commands() -> None:
     # Both should have been called.
     assert check_output.call_args_list == [
         mock.call(
-            'docker compose -f "docker-compose.yml" -p "pytest123" up --build -d',
+            'docker compose -f "docker-compose.yml" -p "pytest123" up --build --wait',
             stderr=subprocess.STDOUT,
             shell=True,
         ),
@@ -242,7 +242,7 @@ def test_multiple_commands() -> None:
             "docker compose",
             "docker-compose.yml",
             docker_compose_project_name="pytest123",
-            docker_setup=["ps", "up --build -d"],
+            docker_setup=["ps", "up --build --wait"],
             docker_cleanup=["down -v", "ps"],
         ) as services:
             assert isinstance(services, Services)
@@ -271,7 +271,7 @@ def test_multiple_commands() -> None:
             shell=True,
         ),
         mock.call(
-            'docker compose -f "docker-compose.yml" -p "pytest123" up --build -d',
+            'docker compose -f "docker-compose.yml" -p "pytest123" up --build --wait',
             stderr=subprocess.STDOUT,
             shell=True,
         ),

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -21,7 +21,7 @@ def test_docker_cleanup(docker_cleanup: List[str]) -> None:
 
 
 def test_docker_setup(docker_setup: List[str]) -> None:
-    assert docker_setup == ["up --build -d"]
+    assert docker_setup == ["up --build --wait"]
 
 
 def test_docker_compose_comand(docker_compose_command: str) -> None:


### PR DESCRIPTION
`--wait` is the better `-d` these days.

I was slightly confused about the docs suggesting to implement a custom `wait_until_responsive` when there was a native waiting mechanism. Judging by [this old discussion](https://github.com/avast/pytest-docker/issues/84) - I could guess that `--wait` did not yet exist back then.